### PR TITLE
Add optional kwargs with proper defaults for spline order and number of control points

### DIFF
--- a/src/bfield.jl
+++ b/src/bfield.jl
@@ -1,8 +1,8 @@
 using NIfTI
 
-function bfield_correction(image_path, mask_path; spline_order=3, num_control_points=4)
+function bfield_correction(image_path, mask_path; spline_order=3, num_control_points=[4, 4, 4])
 	spline_order = pyint(spline_order)
-	num_control_points = pyint(num_control_points)
+	num_control_points = pylist(num_control_points)
 
 	inputImage = sitk.ReadImage(image_path, sitk.sitkFloat32)
 	image = inputImage

--- a/src/bfield.jl
+++ b/src/bfield.jl
@@ -1,32 +1,39 @@
 using NIfTI
 
 function bfield_correction(image_path, mask_path; spline_order=3, num_control_points=[4, 4, 4])
-	spline_order = pyint(spline_order)
-	num_control_points = pylist(num_control_points)
+    spline_order = pyint(spline_order)
+    num_control_points = pylist(num_control_points)
 
-	inputImage = sitk.ReadImage(image_path, sitk.sitkFloat32)
-	image = inputImage
-	
-	maskImage = sitk.ReadImage(mask_path, sitk.sitkUInt8)
-	
-	corrector = sitk.N4BiasFieldCorrectionImageFilter()
-	corrector.SetSplineOrder(spline_order)
-	corrector.SetNumberOfControlPoints(num_control_points)
+    inputImage = sitk.ReadImage(image_path, sitk.sitkFloat32)
+    image = inputImage
 
-	corrected_image = corrector.Execute(image, maskImage)
+    # Check that num_control_points is the same dimension as the image
+    sz = image.GetSize()
+    @assert(
+		length(pyconvert(Vector, sz)) == length(pyconvert(Vector, num_control_points)), 
+		"Incorrect size for number of control points, make sure the vector matches the dimensions of the image"
+	)
+
+    maskImage = sitk.ReadImage(mask_path, sitk.sitkUInt8)
+
+    corrector = sitk.N4BiasFieldCorrectionImageFilter()
+    corrector.SetSplineOrder(spline_order)
+    corrector.SetNumberOfControlPoints(num_control_points)
+
+    corrected_image = corrector.Execute(image, maskImage)
     log_bias_field = corrector.GetLogBiasFieldAsImage(inputImage)
 
-	tempdir = mktempdir()
-	corrected_image_path = joinpath(tempdir, "corrected_image.nii")
-	log_bias_field_path = joinpath(tempdir, "log_bias_field.nii")
+    tempdir = mktempdir()
+    corrected_image_path = joinpath(tempdir, "corrected_image.nii")
+    log_bias_field_path = joinpath(tempdir, "log_bias_field.nii")
 
-	sitk.WriteImage(corrected_image, corrected_image_path)
-	sitk.WriteImage(log_bias_field, log_bias_field_path)
+    sitk.WriteImage(corrected_image, corrected_image_path)
+    sitk.WriteImage(log_bias_field, log_bias_field_path)
 
-	return (
-		niread(image_path),
-		niread(mask_path),
-		niread(log_bias_field_path),
-		niread(corrected_image_path)
-	)
+    return (
+        niread(image_path),
+        niread(mask_path),
+        niread(log_bias_field_path),
+        niread(corrected_image_path)
+    )
 end

--- a/src/bfield.jl
+++ b/src/bfield.jl
@@ -1,12 +1,16 @@
 using NIfTI
 
-function bfield_correction(image_path, mask_path)
+function bfield_correction(image_path, mask_path; spline_order=3, num_control_points=4)
+	spline_order, num_control_points = pylist(spline_order), pylist(num_control_points)
+	
 	inputImage = sitk.ReadImage(image_path, sitk.sitkFloat32)
 	image = inputImage
 	
 	maskImage = sitk.ReadImage(mask_path, sitk.sitkUInt8)
 	
 	corrector = sitk.N4BiasFieldCorrectionImageFilter()
+	corrector.SetSplineOrder(spline_order)
+	corrector.SetNumberOfControlPoints(num_control_points)
 
 	corrected_image = corrector.Execute(image, maskImage)
     log_bias_field = corrector.GetLogBiasFieldAsImage(inputImage)

--- a/src/bfield.jl
+++ b/src/bfield.jl
@@ -1,8 +1,9 @@
 using NIfTI
 
 function bfield_correction(image_path, mask_path; spline_order=3, num_control_points=4)
-	spline_order, num_control_points = pylist(spline_order), pylist(num_control_points)
-	
+	spline_order = pyint(spline_order)
+	num_control_points = pyint(num_control_points)
+
 	inputImage = sitk.ReadImage(image_path, sitk.sitkFloat32)
 	image = inputImage
 	


### PR DESCRIPTION
This keeps the same defaults as in SimpleITK but allows users to modify if needed by using optional kwargs. Below shows the main change
```julia
function bfield_correction(image_path, mask_path; spline_order=3, num_control_points=4)
    ...
    corrector.SetSplineOrder(spline_order)
    corrector.SetNumberOfControlPoints(num_control_points)
    ...
end
```